### PR TITLE
Hint users when BoltDB lock is hold by other process

### DIFF
--- a/commands/dump/dump.go
+++ b/commands/dump/dump.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/cosmoer/bbolt-cli/boltutils"
 	"github.com/cosmoer/bbolt-cli/schema"
@@ -37,8 +38,12 @@ var Command = cli.Command{
 		}
 
 		// Open bolt database.
-		src, err := bolt.Open(SrcPath, 0444, nil)
+		src, err := bolt.Open(SrcPath, 0444, &bolt.Options{Timeout: 2 * time.Second})
 		if err != nil {
+			if err == bolt.ErrTimeout {
+				fmt.Println("Timeout: Unable to acquire the BoltDB file lock. Another process is holding it.")
+				return nil
+			}
 			return err
 		}
 		defer src.Close()

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ import (
 func main() {
 	appInstance := app.New()
 	if err := appInstance.Run(os.Args); err != nil {
-		fmt.Fprintf(os.Stderr, "ctr: %s\n", err)
+		fmt.Fprintf(os.Stderr, "bbolt-cli: %s\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Hi,
Sometime or most of time, containerd is in running state, it always holds the snapshot metadata.db lock, we(bbolt-cli) cann't acquire the lock.
A simple workaround is to copy the metadata.db to a temporary file and then read from it